### PR TITLE
Typo fixed in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ebsite für Bits & Bäume | Augsburg München
+Website für Bits & Bäume | Augsburg München
 
 Basierend auf Symfony 6 und Bootstrap
 


### PR DESCRIPTION
Missing `W` at the beginning of the [README](https://github.com/bitsundbaeume-auxmuc/aux-muc.bits-und-baeume.org/blob/main/README.md)